### PR TITLE
Allow settings for console output of the server logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .classpath
 .project
 .settings
+.idea
 .svn
 target
+jboss-server-manager.iml

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <!-- Artifact Information -->
   <groupId>org.jboss.jbossas</groupId>
   <artifactId>jboss-server-manager</artifactId>
-  <version>1.0.5-SNAPSHOT</version>
+  <version>1.0.6-SNAPSHOT</version>
   <name>JBossAS Server Manager</name>
   <description />
 

--- a/src/main/java/org/jboss/jbossas/servermanager/Server.java
+++ b/src/main/java/org/jboss/jbossas/servermanager/Server.java
@@ -136,6 +136,9 @@ public class Server
   /** the log threshold for the server */
    private String logThreshold = null;
 
+   /** should we output server log to console? */
+   private boolean outputToConsole = true;
+
    /** Property to set the server log Threshold **/
    public final static String SVR_LOG_PROP = "jboss.server.log.threshold";
 
@@ -835,6 +838,16 @@ public class Server
       this.logThreshold = logThreshold;
    }
 
+
+   public boolean outputToConsole()
+   {
+      return outputToConsole;
+   }
+
+   public void setOutputToConsole(boolean outputToConsole)
+   {
+      this.outputToConsole = outputToConsole;
+   }
 
    /*
     * Code below this marker has been ported from jboss-test to supply 

--- a/src/main/java/org/jboss/jbossas/servermanager/Server.java
+++ b/src/main/java/org/jboss/jbossas/servermanager/Server.java
@@ -139,6 +139,9 @@ public class Server
    /** should we output server log to console? */
    private boolean outputToConsole = true;
 
+   /** should be console output prefixed with given string? */
+   private String outputPrefix = null;
+
    /** Property to set the server log Threshold **/
    public final static String SVR_LOG_PROP = "jboss.server.log.threshold";
 
@@ -847,6 +850,16 @@ public class Server
    public void setOutputToConsole(boolean outputToConsole)
    {
       this.outputToConsole = outputToConsole;
+   }
+
+   public String getOutputPrefix()
+   {
+      return outputPrefix;
+   }
+
+   public void setOutputPrefix(String outputPrefix)
+   {
+      this.outputPrefix = outputPrefix;
    }
 
    /*

--- a/src/main/java/org/jboss/jbossas/servermanager/ServerController.java
+++ b/src/main/java/org/jboss/jbossas/servermanager/ServerController.java
@@ -106,8 +106,10 @@ public abstract class ServerController
       File binDir = new File(manager.getJBossHome(), "/bin");
       final Process process = Runtime.getRuntime().exec(execCmd, null, binDir);
 
-      new Thread(new ConsoleConsumer(process.getInputStream())).start();
-      new Thread(new ConsoleConsumer(process.getErrorStream())).start();
+      if (server.outputToConsole()) {
+         new Thread(new ConsoleConsumer(process.getInputStream(), "eap5: ")).start();
+         new Thread(new ConsoleConsumer(process.getErrorStream(), "eap5: ")).start();
+      }
 
       final BufferedReader errStream = new BufferedReader(new InputStreamReader(process.getErrorStream()));
       final BufferedReader inStream = new BufferedReader(new InputStreamReader(process.getInputStream()));
@@ -641,24 +643,25 @@ public abstract class ServerController
    }
 
    private static class ConsoleConsumer implements Runnable {
-     private final InputStream stream;
+      private final InputStream stream;
+      private final String prefix;
 
-    ConsoleConsumer(InputStream stream) {
-        this.stream = stream;
-     }
+      ConsoleConsumer(InputStream stream, String prefix) {
+         this.stream = stream;
+         this.prefix = prefix != null ? prefix : "";
+      }
 
-             @Override
-             public void run() {
-                 final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-                 String line = null;
-                 try {
-                     while ((line = reader.readLine()) != null) {
-                         System.out.println(line);
-                     }
-                 } catch (IOException e) {
-
-                 }
-
-             }
+      public void run() {
+         final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+         String line = null;
+         try {
+            while ((line = reader.readLine()) != null) {
+               System.out.println(prefix + line);
+            }
+         } catch (IOException e) {
+            e.printStackTrace();
          }
+      }
+   }
+
 }

--- a/src/main/java/org/jboss/jbossas/servermanager/ServerController.java
+++ b/src/main/java/org/jboss/jbossas/servermanager/ServerController.java
@@ -107,8 +107,9 @@ public abstract class ServerController
       final Process process = Runtime.getRuntime().exec(execCmd, null, binDir);
 
       if (server.outputToConsole()) {
-         new Thread(new ConsoleConsumer(process.getInputStream(), "eap5: ")).start();
-         new Thread(new ConsoleConsumer(process.getErrorStream(), "eap5: ")).start();
+         String prefix = server.getOutputPrefix() == null ? "" : (server.getOutputPrefix() + ": ");
+         new Thread(new ConsoleConsumer(process.getInputStream(), prefix)).start();
+         new Thread(new ConsoleConsumer(process.getErrorStream(), prefix)).start();
       }
 
       final BufferedReader errStream = new BufferedReader(new InputStreamReader(process.getErrorStream()));


### PR DESCRIPTION
Server output to console is optinal and can have optional prefix to better distinguish individual server logs in multi-server scenarios.
